### PR TITLE
feat: remove "circular" reference to exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,4 +24,4 @@ module.exports = function deepFreeze(obj) {
     return obj;
 }
 
-module.exports.default = module.exports;
+module.exports.default = deepFreeze;


### PR DESCRIPTION
This helps build tools (rollup, etc) make better choices about whether the module needs to be wrapped or not.  The fact that you reference `module.exports`  makes the heuristics of the build system thing you may be doing something fancy.  Just simply setting the value directly avoids this and produces the same result.

Reference:
https://github.com/rollup/plugins/blob/b12acfa910905d2cf2ec486be9f596de4de151bf/packages/commonjs/src/transform.js#L418

Compiled code Before:

```
   8         function createCommonjsModule(fn, basedir, module) {
   9                 return module = {
  10                         path: basedir,
  11                         exports: {},
  12                         require: function (path, base) {
  13                                 return commonjsRequire(path, (base === undefined || base === null) ? module.path : base);
  14                         }
  15                 }, fn(module, module.exports), module.exports;
  16         }
  17
  18         function commonjsRequire () {
  19                 throw new Error('Dynamic requires are not currently supported by @rollup/plugin-commonjs');
  20         }
  21
  22         var deepFreezeEs6 = createCommonjsModule(function (module) {
  23         module.exports = function deepFreeze(obj) {
  24             if (obj instanceof Map) {
```

After:

```
   5     var deepFreezeEs6 = function deepFreeze(obj) {
   6         if (obj instanceof Map) {
```