### PR TITLE
feat: freeze contents of Maps and Sets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,12 @@
 /* eslint-disable no-multi-assign */
 
 export function deepFreeze(obj) {
+  function nullishSafeDeepFreeze(obj) {
+    if (obj !== null && obj !== undefined) {
+      deepFreeze(obj);
+    }
+  }
+
   if (obj instanceof Map) {
     obj.clear =
       obj.delete =
@@ -9,8 +15,8 @@ export function deepFreeze(obj) {
           throw new Error("map is read-only");
         };
     for (const [key, value] of obj.entries()) {
-      deepFreeze(key);
-      deepFreeze(value);
+      nullishSafeDeepFreeze(key);
+      nullishSafeDeepFreeze(value);
     }
   } else if (obj instanceof Set) {
     obj.add =
@@ -20,7 +26,7 @@ export function deepFreeze(obj) {
           throw new Error("set is read-only");
         };
     for (const value of obj.values()) {
-      deepFreeze(value);
+      nullishSafeDeepFreeze(value);
     }
   } else if (obj instanceof WeakSet) {
     obj.add = obj.delete = function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,10 @@ export function deepFreeze(obj) {
         function () {
           throw new Error("map is read-only");
         };
+    for (const [key, value] of obj.entries()) {
+      deepFreeze(key);
+      deepFreeze(value);
+    }
   } else if (obj instanceof Set) {
     obj.add =
       obj.clear =
@@ -15,6 +19,9 @@ export function deepFreeze(obj) {
         function () {
           throw new Error("set is read-only");
         };
+    for (const value of obj.values()) {
+      deepFreeze(value);
+    }
   } else if (obj instanceof WeakSet) {
     obj.add = obj.delete = function () {
       throw new Error("WeakSet is read-only");

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -12,7 +12,7 @@ test("unexpected non object: null", () => {
   );
 });
 
-test("freeze map", () => {
+test("freeze Map", () => {
   const obj = deepFreeze({
     map: new Map([
       [1, 1],
@@ -27,7 +27,46 @@ test("freeze map", () => {
   );
 });
 
-test("freeze set", () => {
+test("freeze Map keys", () => {
+  const key = { a: 1 };
+  deepFreeze({
+    map: new Map([[key, 1]]),
+  });
+  assert.throws(
+    () => {
+      key.y = 2;
+    },
+    { message: "Cannot add property y, object is not extensible" },
+  );
+});
+
+test("freeze Map values", () => {
+  const value = { a: 1 };
+  deepFreeze({
+    map: new Map([[1, value]]),
+  });
+  assert.throws(
+    () => {
+      value.y = 2;
+    },
+    { message: "Cannot add property y, object is not extensible" },
+  );
+});
+
+test("freeze nested Map", () => {
+  const nestedValue = { a: 1 };
+  deepFreeze({
+    map: new Map([[1, new Map([[2, nestedValue]])]]),
+  });
+  assert.throws(
+    () => {
+      nestedValue.y = 2;
+    },
+    { message: "Cannot add property y, object is not extensible" },
+  );
+});
+
+test("freeze Set", () => {
   const obj = deepFreeze({
     set: new Set([1, 2]),
   });
@@ -39,7 +78,33 @@ test("freeze set", () => {
   );
 });
 
-test("freeze WeekSet", () => {
+test("freeze Set values", () => {
+  const value = { a: 1 };
+  deepFreeze({
+    set: new Set([value]),
+  });
+  assert.throws(
+    () => {
+      value.y = 2;
+    },
+    { message: "Cannot add property y, object is not extensible" },
+  );
+});
+
+test("freeze nested Set", () => {
+  const nestedSetValue = { a: 1 };
+  deepFreeze({
+    set: new Set([new Set([nestedSetValue])]),
+  });
+  assert.throws(
+    () => {
+      nestedSetValue.y = 2;
+    },
+    { message: "Cannot add property y, object is not extensible" },
+  );
+});
+
+test("freeze WeakSet", () => {
   const obj = deepFreeze({
     weakSet: new WeakSet([{}, {}]),
   });
@@ -51,7 +116,7 @@ test("freeze WeekSet", () => {
   );
 });
 
-test("freeze WeekMap", () => {
+test("freeze WeakMap", () => {
   const obj = deepFreeze({
     weakMap: new WeakMap([[{}, {}]]),
   });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -3,13 +3,35 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { deepFreeze } from "./index.js";
 
-test("unexpected non object: null", () => {
-  assert.throws(
-    () => {
-      deepFreeze(null);
-    },
-    { message: "Cannot convert undefined or null to object" },
-  );
+const nullishValues = [null, undefined];
+
+nullishValues.forEach((nullishValue) => {
+  test(`unexpected non object: ${nullishValue}`, () => {
+    assert.throws(
+      () => {
+        deepFreeze(nullishValue);
+      },
+      { message: "Cannot convert undefined or null to object" },
+    );
+  });
+
+  test(`can freeze Map with ${nullishValue} key`, () => {
+    deepFreeze({
+      map: new Map([[nullishValue, 1]]),
+    });
+  });
+
+  test(`can freeze Map with ${nullishValue} value`, () => {
+    deepFreeze({
+      map: new Map([[1, nullishValue]]),
+    });
+  });
+
+  test(`can freeze Set with ${nullishValue} value`, () => {
+    deepFreeze({
+      set: new Set([nullishValue]),
+    });
+  });
 });
 
 test("freeze Map", () => {


### PR DESCRIPTION
I ran into an issue whereby I assumed *deep* freeze froze the contents of Sets and Maps but it doesn't.

This PR adds this functionality.

---

If this makes sense to merge, I'd like to point out that this problem also applies to WeakSet and WeakMap and a similar change may be warranted there.

I haven't yet done this because I'm not 100% sure what should be done for those two as you can't iterate over their contents. You could potentially change the getters to freeze things on the way out but the objects wouldn't be frozen until they were retrieved. Maybe that's alright though?